### PR TITLE
feat: make model parameter optional with default value

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,8 +57,12 @@ jobs:
               "type": "object",
               "properties": {
                 "capital": { "type": "string" }
-              }
+              },
+              "required": ["capital"],
+              "additionalProperties": false
             }
       - run: echo "${{ steps.prompt.outputs.text }}"
       - run: |
+          echo "Generated JSON:"
+          echo '${{ steps.prompt-with-structured-output.outputs.json }}'
           echo "Capital of Costa Rica: ${{ fromJson(steps.prompt-with-structured-output.outputs.json).capital }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,4 +47,17 @@ jobs:
         with:
           prompt: 'Why is the sky blue?'
           api-key: ${{ secrets.AI_GATEWAY_API_KEY }}
+      - uses: ./ # Uses the action in the root directory
+        id: prompt-with-structured-output
+        with:
+          prompt: 'What is the capital of France?'
+          api-key: ${{ secrets.AI_GATEWAY_API_KEY }}
+          schema: |
+            {
+              "type": "object",
+              "properties": {
+                "capital": { "type": "string" }
+              }
+            }
       - run: echo '${{ steps.prompt.outputs.text }}'
+      - run: echo '${{ steps.prompt-with-structured-output.outputs.json }}'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,6 +46,5 @@ jobs:
         id: prompt
         with:
           prompt: 'Why is the sky blue?'
-          model: 'openai/gpt5'
           api-key: ${{ secrets.AI_GATEWAY_API_KEY }}
       - run: echo '${{ steps.prompt.outputs.text }}'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,5 +59,5 @@ jobs:
                 "capital": { "type": "string" }
               }
             }
-      - run: echo '${{ steps.prompt.outputs.text }}'
-      - run: echo '${{ steps.prompt-with-structured-output.outputs.json }}'
+      - run: echo "${{ steps.prompt.outputs.text }}"
+      - run: echo "${{ steps.prompt-with-structured-output.outputs.json }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,7 @@ jobs:
       - uses: ./ # Uses the action in the root directory
         id: prompt-with-structured-output
         with:
-          prompt: 'What is the capital of France?'
+          prompt: 'What is the capital of Costa Rica?'
           api-key: ${{ secrets.AI_GATEWAY_API_KEY }}
           schema: |
             {
@@ -60,4 +60,5 @@ jobs:
               }
             }
       - run: echo "${{ steps.prompt.outputs.text }}"
-      - run: echo "${{ steps.prompt-with-structured-output.outputs.json }}"
+      - run: |
+          echo "Capital of Costa Rica: ${{ fromJson(steps.prompt-with-structured-output.outputs.json).capital }}"

--- a/action.yml
+++ b/action.yml
@@ -13,7 +13,8 @@ inputs:
     required: true
   model: 
     description: "An identifier from the list of provider models supported by the AI Gateway: https://vercel.com/ai-gateway/models"
-    required: true
+    default: "xai/grok-3"
+    required: false
   schema:
     description: "Optional JSON schema for structured output. When provided, the action will use generateObject and return structured JSON data."
     required: false

--- a/main.js
+++ b/main.js
@@ -6,7 +6,7 @@ import * as ai from "ai";
 import { main } from "./lib/main.js";
 
 const prompt = core.getInput("prompt");
-const model = core.getInput("model");
+const model = core.getInput("model", { required: false });
 const apiKey = core.getInput("api-key");
 const schema = core.getInput("schema");
 

--- a/readme.md
+++ b/readme.md
@@ -9,7 +9,7 @@ GitHub Action to interact with different AI model providers.
 In order to use this action, you need to 
 
 1. [create an API KEY for the AI Gateway](https://vercel.com/d?to=%2F%5Bteam%5D%2F%7E%2Fai%2Fapi-keys)
-2. [pick one of the supported models](https://vercel.com/ai-gateway/models)
+2. Optionally specify a model (defaults to `xai/grok-3` if not provided)
 
 
 ### Basic Text Generation
@@ -29,7 +29,6 @@ jobs:
         id: prompt
         with:
           prompt: 'Why is the sky blue?'
-          model: 'openai/gpt5'
           api-key: ${{ secrets.AI_GATEWAY_API_KEY }}
       - run: echo ${{ steps.prompt.outputs.text }}
 ```
@@ -101,7 +100,7 @@ jobs:
 
 ### `model`
 
-**Required.** An identifier from the list of provider models supported by the AI Gateway: https://vercel.com/ai-gateway/models
+**Optional.** An identifier from the list of provider models supported by the AI Gateway: https://vercel.com/ai-gateway/models. Defaults to `xai/grok-3` if not provided.
 
 ### `schema`
 


### PR DESCRIPTION
This pull request updates the GitHub Action to make the `model` input optional, defaulting to `xai/grok-3` if not specified, and improves support for structured output using JSON schemas. It also updates documentation and workflow examples to reflect these changes.

The justification to make this PR is that this change aligns with the official Vercel AI Gateway documentation, which states that `xai/grok-3` is set as the default model. According to the [AI Gateway Models & Providers documentation](https://vercel.com/docs/ai-gateway/models-and-providers#as-part-of-an-ai-sdk-function-call):

**Input handling improvements:**

* Made the `model` input optional in `action.yml`, set its default value to `xai/grok-3`, and updated the description to reflect this change.
* Updated `main.js` to retrieve the `model` input as optional, aligning with the new default behavior.

**Documentation updates:**

* Updated the `readme.md` to state that specifying a model is optional and defaults to `xai/grok-3`. Also clarified the `model` input documentation. [[1]](diffhunk://#diff-5a831ea67cf5cf8703b0de46901ab25bd191f56b320053be9332d9a3b0d01d15L12-R12) [[2]](diffhunk://#diff-5a831ea67cf5cf8703b0de46901ab25bd191f56b320053be9332d9a3b0d01d15L104-R103)
* Updated example workflow YAML in `readme.md` to remove the explicit `model` input, demonstrating the new default behavior.

**Workflow and structured output enhancements:**

* Enhanced the test workflow in `.github/workflows/test.yml` to add an example of using structured output with a JSON schema, and updated the usage of the action accordingly.